### PR TITLE
Fixes index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,8 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
   <title>Pinterest and David Isnt Here</title>
-  
-  
+
+
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/css/materialize.min.css">
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <script type="text/javascript" src="https://code.jquery.com/jquery-3.2.1.min.js"></script>
@@ -15,9 +15,6 @@
   <script src="node_modules/angular/angular.min.js"></script>
   <script src="node_modules/angular-route/angular-route.min.js"></script>
   <link rel="stylesheet" type="text/css" href="css/main.css">
-  <script src="dist/project.js"></script>
-
-
 </head>
 <body ng-app="PinterestApp">
   <div ng-view></div>
@@ -26,21 +23,6 @@
 
 
 
-  <script src='app/app.js'></script>
-  <script type="text/javascript" src='app/values/FBCreds.js'></script>
-
-
-  <script src="app/factories/AuthFactory.js"></script>
-  <script src="app/factories/BoardFactory.js"></script>
-  <script src="app/factories/PinFactory.js"></script>
-
-  <script src="app/controllers/AuthCtrl.js"></script>
-  <script src="app/controllers/EditBoardCtrl.js"></script>
-  <script src="app/controllers/EditPinCtrl.js"></script>
-  <script src="app/controllers/NewBoardCtrl.js"></script>
-  <script src="app/controllers/NewPinCtrl.js"></script>
-  <script src="app/controllers/ViewBoardCtrl.js"></script>
-  <script src="app/controllers/ViewPinCtrl.js"></script>
-
+  <script src="dist/project.js"></script>
 </body>
 </html>


### PR DESCRIPTION
`index.html`
We're using `grunt-angular-builder` (like `browserify`) to compile our AngularJS code into one file, called `dist/project.js`
This PR removes all other `script` tags with the single `dist/project.js` necessary.